### PR TITLE
CI: Dep cooldown

### DIFF
--- a/.continue/rules/10-sveltekit-style.md
+++ b/.continue/rules/10-sveltekit-style.md
@@ -1,0 +1,16 @@
+---
+name: SvelteKit style
+---
+
+- Follow the repository's existing SvelteKit structure and conventions.
+- Use current Svelte patterns and avoid legacy syntax unless the repository already uses it.
+- Prefer small, focused components over large multi-purpose files.
+- Keep page and layout files thin; move reusable logic into nearby modules when appropriate.
+- Prefer server-side loading and form actions when they fit the existing app architecture.
+- Do not introduce unnecessary client-side state or browser-only logic into server code.
+- Preserve route structure, load behavior, and data flow unless a change is explicitly requested.
+- Prefer explicit prop and return typing where the surrounding codebase uses TypeScript.
+- Reuse existing components, stores, utilities, and helpers before creating new abstractions.
+- Keep accessibility in mind: use semantic HTML, proper labels, and keyboard-friendly interactions.
+- Preserve existing error/loading UX patterns unless a change is explicitly requested.
+- Avoid adding new dependencies unless explicitly requested.

--- a/.continue/rules/20-tailwind-ui-style.md
+++ b/.continue/rules/20-tailwind-ui-style.md
@@ -1,0 +1,15 @@
+---
+name: Tailwind UI style
+---
+
+- Follow the repository's existing Tailwind and design patterns.
+- Prefer utility classes over custom CSS when the existing codebase does the same.
+- Reuse existing component patterns, spacing scales, and layout conventions before creating new ones.
+- Keep class lists readable and grouped in a consistent order.
+- Avoid unnecessary wrapper divs and deeply nested markup.
+- Prefer responsive, mobile-first layouts.
+- Preserve existing color, typography, spacing, and dark-mode conventions unless explicitly requested.
+- Do not introduce one-off visual styles if an existing utility pattern already solves the problem.
+- Keep interactive states clear, including hover, focus, active, disabled, and error states.
+- Prefer semantic HTML first, Tailwind second.
+- When updating UI, keep diffs minimal and avoid unrelated visual churn.

--- a/.continue/rules/30-eslint-prettier.md
+++ b/.continue/rules/30-eslint-prettier.md
@@ -1,0 +1,14 @@
+---
+name: ESLint and Prettier
+---
+
+- Prefer fixing lint issues in touched files rather than doing broad repo-wide cleanup.
+- Prefer formatting only edited files unless explicitly requested.
+- Follow the repository's existing ESLint and Prettier configuration.
+- Do not disable lint rules unless explicitly requested or clearly justified.
+- Prefer code changes that satisfy lint rules over inline ignores.
+- If an ignore is necessary, keep it narrow and explain why.
+- Preserve existing import ordering and formatting conventions.
+- When proposing verification commands, use the repository's package manager and scripts.
+- State clearly which checks were run and which were not run.
+- If a full lint or format pass would create broad unrelated diffs, avoid it unless explicitly requested.

--- a/.continue/rules/40-sveltekit-repo-boundaries.md
+++ b/.continue/rules/40-sveltekit-repo-boundaries.md
@@ -1,0 +1,13 @@
+---
+name: SvelteKit repo boundaries
+---
+
+- Do not rename routes, move files, or change package layout unless explicitly requested.
+- Do not rewrite working components, stores, hooks, or utilities without a clear need.
+- Preserve public component APIs, exported helpers, and route behavior unless explicitly requested.
+- Avoid broad refactors across pages, layouts, and shared UI unless the request requires it.
+- Preserve existing environment variable usage, adapter setup, and deployment-related configuration unless explicitly requested.
+- Do not change generated files, build output, lockfiles, or package versions unless explicitly requested.
+- Preserve existing Tailwind, ESLint, Prettier, and TypeScript config unless the request is specifically about tooling.
+- When changing UI behavior, data loading, navigation, or form handling, call out user-visible behavior changes explicitly.
+- Prefer minimal diffs that solve the requested problem directly.

--- a/.continue/rules/50-sveltekit-verification.md
+++ b/.continue/rules/50-sveltekit-verification.md
@@ -1,0 +1,12 @@
+---
+name: SvelteKit verification
+---
+
+- Prefer targeted verification over broad full-project runs.
+- Prefer checking the nearest relevant route, component, or module first.
+- Prefer linting only touched files before running broader checks.
+- Prefer type-checking the project when changes affect routes, load functions, actions, stores, or shared types.
+- Prefer running the smallest relevant test scope if tests exist.
+- Use the repository's existing package manager and scripts.
+- State clearly which verification steps were run and which were not run.
+- If a command is expensive or likely to touch unrelated areas, note that before recommending it.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ bun.lockb
 
 # Miscellaneous
 /static/
+.continue


### PR DESCRIPTION
## Summary

- Added dependabot cooldowns to avoid supply chain attacks
- Also added continue rules for sveltekit

## Changes

- [ ] Content update (papers/schedule/leadership)
- [ ] UI update (routes/components/styles)
- [x] CI/Deploy update (workflows)
- [ ] Dependencies

## Checklist

- [x] `make lint`
- [x] `make check`
- [x] `make build`
- [x] Pages links/routes still work (esp. `/papers` and `/schedule`)
- [ ] Updated data in `src/lib/data/` if applicable

## Screenshots (optional)

-
