### PR TITLE
0.0.2: Chore, dep bump

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,4 @@
 {
 	"$schema": "https://unpkg.com/knip@latest/schema.json",
-	"ignoreDependencies": ["@sveltejs/adapter-auto"],
 	"include": ["dependencies", "devDependencies"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"knip": "6.4.1",
 				"prettier": "^3.8.2",
 				"prettier-plugin-svelte": "^3.5.1",
-				"svelte": "5.55.1",
+				"svelte": "5.55.3",
 				"svelte-check": "4.4.6",
 				"typescript": "^5.9.3",
 				"typescript-eslint": "8.58.0",
@@ -3900,9 +3900,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.55.1",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.1.tgz",
-			"integrity": "sha512-QjvU7EFemf6mRzdMGlAFttMWtAAVXrax61SZYHdkD6yoVGQ89VeyKfZD4H1JrV1WLmJBxWhFch9H6ig/87VGjw==",
+			"version": "5.55.3",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.3.tgz",
+			"integrity": "sha512-dS1N+i3bA1v+c4UDb750MlN5vCO82G6vxh8HeTsPsTdJ1BLsN1zxSyDlIdBBqUjqZ/BxEwM8UrFf98aaoVnZFQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
 	"name": "ml-paper-reading-group-site",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ml-paper-reading-group-site",
-			"version": "0.0.1",
+			"version": "0.0.2",
 			"devDependencies": {
 				"@eslint/compat": "^2.0.4",
 				"@eslint/js": "^9.39.1",
-				"@sveltejs/adapter-auto": "^7.0.1",
 				"@sveltejs/adapter-static": "^3.0.10",
-				"@sveltejs/kit": "^2.53.4",
+				"@sveltejs/kit": "^2.57.1",
 				"@sveltejs/vite-plugin-svelte": "^6.2.1",
 				"@types/node": "25.5.2",
 				"eslint": "^10.1.0",
@@ -1815,16 +1814,6 @@
 				"acorn": "^8.9.0"
 			}
 		},
-		"node_modules/@sveltejs/adapter-auto": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-7.0.1.tgz",
-			"integrity": "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"@sveltejs/kit": "^2.0.0"
-			}
-		},
 		"node_modules/@sveltejs/adapter-static": {
 			"version": "3.0.10",
 			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.10.tgz",
@@ -1836,9 +1825,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.56.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.56.1.tgz",
-			"integrity": "sha512-9hDOl3yUh8UXWt+mN29dbcdrW0vNwPvMqi01y2Mw+ceErNIISh8MeEY7fXT2Dx1CjC/kfsVqrbxw7DifYr4hsg==",
+			"version": "2.58.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.58.0.tgz",
+			"integrity": "sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"eslint-plugin-svelte": "3.17.0",
 				"globals": "^17.4.0",
 				"knip": "6.4.1",
-				"prettier": "^3.8.1",
+				"prettier": "^3.8.2",
 				"prettier-plugin-svelte": "^3.5.1",
 				"svelte": "5.55.1",
 				"svelte-check": "4.4.6",
@@ -3631,9 +3631,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@sveltejs/adapter-static": "^3.0.10",
 				"@sveltejs/kit": "^2.57.1",
 				"@sveltejs/vite-plugin-svelte": "^6.2.1",
-				"@types/node": "25.5.2",
+				"@types/node": "25.6.0",
 				"eslint": "^10.1.0",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-svelte": "3.17.0",
@@ -1945,13 +1945,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.5.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-			"integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.18.0"
+				"undici-types": "~7.19.0"
 			}
 		},
 		"node_modules/@types/trusted-types": {
@@ -4104,9 +4104,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ml-paper-reading-group-site",
 	"private": true,
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"prettier-plugin-svelte": "^3.5.1",
 		"prettier": "^3.8.2",
 		"svelte-check": "4.4.6",
-		"svelte": "5.55.1",
+		"svelte": "5.55.3",
 		"typescript-eslint": "8.58.0",
 		"typescript": "^5.9.3",
 		"vite": "7.3.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.57.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
-		"@types/node": "25.5.2",
+		"@types/node": "25.6.0",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "3.17.0",
 		"eslint": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"eslint": "^10.1.0",
 		"globals": "^17.4.0",
 		"prettier-plugin-svelte": "^3.5.1",
-		"prettier": "^3.8.1",
+		"prettier": "^3.8.2",
 		"svelte-check": "4.4.6",
 		"svelte": "5.55.1",
 		"typescript-eslint": "8.58.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,8 @@
 	"devDependencies": {
 		"@eslint/compat": "^2.0.4",
 		"@eslint/js": "^9.39.1",
-		"@sveltejs/adapter-auto": "^7.0.1",
 		"@sveltejs/adapter-static": "^3.0.10",
-		"@sveltejs/kit": "^2.53.4",
+		"@sveltejs/kit": "^2.57.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"@types/node": "25.5.2",
 		"eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
## Summary

- Bumps several deps

### PRs Closed: 
- PR #90 
- PR #91 
- PR #92 
- PR #93 
- PR #94 

## Changes

- [ ] Content update (papers/schedule/leadership)
- [ ] UI update (routes/components/styles)
- [ ] CI/Deploy update (workflows)
- [x] Dependencies

## Checklist

- [x] `make lint`
- [x] `make check`
- [x] `make build`
- [x] `make deps.check`
- [x] Pages links/routes still work (esp. `/papers` and `/schedule`)
- [x] Updated data in `src/lib/data/` if applicable