### PR TITLE
Chore: dep bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"knip": "6.5.0",
 				"prettier": "^3.8.2",
 				"prettier-plugin-svelte": "^3.5.1",
-				"svelte": "5.55.3",
+				"svelte": "5.55.5",
 				"svelte-check": "4.4.6",
 				"typescript": "^6.0.3",
 				"typescript-eslint": "8.58.0",
@@ -3821,9 +3821,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.55.3",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.3.tgz",
-			"integrity": "sha512-dS1N+i3bA1v+c4UDb750MlN5vCO82G6vxh8HeTsPsTdJ1BLsN1zxSyDlIdBBqUjqZ/BxEwM8UrFf98aaoVnZFQ==",
+			"version": "5.55.5",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
+			"integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-svelte": "3.17.1",
 				"globals": "^17.5.0",
-				"knip": "6.5.0",
+				"knip": "6.7.0",
 				"prettier": "^3.8.2",
 				"prettier-plugin-svelte": "^3.5.1",
 				"svelte": "5.55.5",
@@ -768,48 +768,10 @@
 				"@emnapi/runtime": "^1.7.1"
 			}
 		},
-		"node_modules/@nodelib/fs.scandir": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "2.0.5",
-				"run-parallel": "^1.1.9"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@nodelib/fs.stat": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@nodelib/fs.walk": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.scandir": "2.1.5",
-				"fastq": "^1.6.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/@oxc-parser/binding-android-arm-eabi": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.126.0.tgz",
-			"integrity": "sha512-svyoHt25J4741QJ5aa4R+h0iiBeSRt63Lr3aAZcxy2c/NeSE1IfDeMnSij6rIg7EjxkdlXzz613wUjeCeilBNA==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
+			"integrity": "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==",
 			"cpu": [
 				"arm"
 			],
@@ -824,9 +786,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-android-arm64": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.126.0.tgz",
-			"integrity": "sha512-hPEBRKgplp1mG9GkINFsr4JVMDNrGJLOqfDaadTWpAoTnzYR5Rmv8RMvB3hJZpiNvbk1aacopdHUP1pggMQ/cw==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.127.0.tgz",
+			"integrity": "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==",
 			"cpu": [
 				"arm64"
 			],
@@ -841,9 +803,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-darwin-arm64": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.126.0.tgz",
-			"integrity": "sha512-ccRpu9sdYmznePJQG5halhs0FW5tw5a8zRSoZXOzM1OjoeZ4jiRRruFiPclsD59edoVAK1l83dvfjWz1nQi6lg==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.127.0.tgz",
+			"integrity": "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==",
 			"cpu": [
 				"arm64"
 			],
@@ -858,9 +820,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-darwin-x64": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.126.0.tgz",
-			"integrity": "sha512-CHB4zVjNSKqx8Fw9pHowzQQnjjuq04i4Ng0Avj+DixlwhwAoMYqlFbocYIlbg+q3zOLGlm7vEHm83jqEMitnyg==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.127.0.tgz",
+			"integrity": "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==",
 			"cpu": [
 				"x64"
 			],
@@ -875,9 +837,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-freebsd-x64": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.126.0.tgz",
-			"integrity": "sha512-RQ3nEJdcDKBfBjmLJ3Vl1d0KQERPV1P8eUrnBm7+VTYyoaJSPLVFuPg1mlD1hk3n0/879VLFMfusFkBal4ssWQ==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.127.0.tgz",
+			"integrity": "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==",
 			"cpu": [
 				"x64"
 			],
@@ -892,9 +854,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.126.0.tgz",
-			"integrity": "sha512-onipc2wCDA7Bauzb4KK1mab0GsEDf4ujiIfWECdnmY/2LlzAoX3xdQRLAUyEDB1kn3yilHBrkmXDdHluyHXxiw==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.127.0.tgz",
+			"integrity": "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==",
 			"cpu": [
 				"arm"
 			],
@@ -909,9 +871,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.126.0.tgz",
-			"integrity": "sha512-5BuJJPohrV5NJ8lmcYOMbfRCUGoYH5J9HZHeuqOLwkHXWAuPMN3X1h8bC/2mWjmosdbfTtmyIdX3spS/TkqKNg==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.127.0.tgz",
+			"integrity": "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==",
 			"cpu": [
 				"arm"
 			],
@@ -926,9 +888,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.126.0.tgz",
-			"integrity": "sha512-r2KApRgm2pOJaduRm6GOT8x0whcr67AyejNkSdzPt34GJ+Y3axcXN2mwlTs+8lfO/SSmpO5ZJGYiHYnxEE0jkw==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.127.0.tgz",
+			"integrity": "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -943,9 +905,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm64-musl": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.126.0.tgz",
-			"integrity": "sha512-FQ+MMh7MT0Dr/u8+RWmWKlfoeWPQyHDbhhxJShJlYtROXXPHsRs9EvmQOZZ3sx4Nn7JU8NX+oyw2YzQ7anBJcA==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.127.0.tgz",
+			"integrity": "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==",
 			"cpu": [
 				"arm64"
 			],
@@ -960,9 +922,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.126.0.tgz",
-			"integrity": "sha512-Wv/T8C98hRQhGTlx2XFyLn5raRMp9U1lOQD+YnXNgAr7wHbJJpZ8mDBU7Rw+M3WytGcGTFcr6kqgfyQeHVtLbQ==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.127.0.tgz",
+			"integrity": "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -977,9 +939,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.126.0.tgz",
-			"integrity": "sha512-DHx1rT1zauW0ZbLHOiQh5AC9Xs3UkWx2XmfZHs+7nnWYr3sagrufoUQC+/XPwwjMIlCFXiFGM0sFh3TyOCZwqA==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.127.0.tgz",
+			"integrity": "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -994,9 +956,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.126.0.tgz",
-			"integrity": "sha512-umDc2mTShH0U2zcEYf8mIJ163seLJNn54ZUZYeI5jD4qlg9izPwoLrC2aNPKlMJTu6u/ysmQWiEvIiaAG+INkw==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.127.0.tgz",
+			"integrity": "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1011,9 +973,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.126.0.tgz",
-			"integrity": "sha512-PXXeWayclRtO1pxQEeCpiqIglQdhK2mAI2VX5xnsWdImzSB5GpoQ8TNw7vTCKk2k+GZuxl+q1knncidjCyUP9w==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.127.0.tgz",
+			"integrity": "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==",
 			"cpu": [
 				"s390x"
 			],
@@ -1028,9 +990,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-x64-gnu": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.126.0.tgz",
-			"integrity": "sha512-wzocjxm34TbB3bFlqG65JiLtvf6ZDg2ZxRkLLbgXwDQUNU+0MPjQN8zy/0jBKNA5fnPLk3XeVdZ7Uin+7+CVkg==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.127.0.tgz",
+			"integrity": "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1045,9 +1007,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-x64-musl": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.126.0.tgz",
-			"integrity": "sha512-e83uftP60jmkPs2+CW6T6A1GYzN2H6IumDAiTntv9WyHR73PI3ImHNBkYqnA3ukeKI3xjcCbhSh9QeJWmufxGQ==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.127.0.tgz",
+			"integrity": "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==",
 			"cpu": [
 				"x64"
 			],
@@ -1062,9 +1024,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-openharmony-arm64": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.126.0.tgz",
-			"integrity": "sha512-4WiOILHnPrTDY2/L4mE6PZCYwLN1d3ghma6BuTJ452CCgzRMt3uFplCtR+o3r9zdUWJYb370UizpI9CUcWXr1A==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.127.0.tgz",
+			"integrity": "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1079,9 +1041,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-wasm32-wasi": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.126.0.tgz",
-			"integrity": "sha512-Y17hhnrQTrxgAxAyAq401vnN9URsAL4s5AjqpG1NDsXSlhe1yBNnns+rC2P6xcMoitgX5nKH2ryYt9oiFRlzLw==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.127.0.tgz",
+			"integrity": "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==",
 			"cpu": [
 				"wasm32"
 			],
@@ -1094,7 +1056,7 @@
 				"@napi-rs/wasm-runtime": "^1.1.4"
 			},
 			"engines": {
-				"node": ">=14.0.0"
+				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
@@ -1121,9 +1083,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.126.0.tgz",
-			"integrity": "sha512-Znug1u1iRvT4VC3jANz6nhGBHsFwEFMxuimYpJFwMtsB6H5FcEoZRMmH26tHkSTD03JvDmG+gB65W3ajLjPcSw==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.127.0.tgz",
+			"integrity": "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1138,9 +1100,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.126.0.tgz",
-			"integrity": "sha512-qrw7mx5hFFTxVSXToOA40hpnjgNB/DJprZchtB4rDKNLKqkD3F26HbzaQeH1nxAKej0efSZfJd5Sw3qdtOLGhw==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.127.0.tgz",
+			"integrity": "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==",
 			"cpu": [
 				"ia32"
 			],
@@ -1155,9 +1117,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-win32-x64-msvc": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.126.0.tgz",
-			"integrity": "sha512-ibB1s+mPUFXvS7MFJO2jpw/aCNs/P6ifnWlRyTYB+WYBpniOiCcHQQskZneJtwcjQMDRol3RGG3ihoYnzXSY4w==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.127.0.tgz",
+			"integrity": "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==",
 			"cpu": [
 				"x64"
 			],
@@ -1172,9 +1134,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
-			"integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+			"integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -2780,16 +2742,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/fastq": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"reusify": "^1.0.4"
-			}
-		},
 		"node_modules/fd-package-json": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
@@ -3050,9 +3002,9 @@
 			}
 		},
 		"node_modules/knip": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/knip/-/knip-6.5.0.tgz",
-			"integrity": "sha512-84xSq/g8CtPWLJcY5WZeGWj/pbqQxJRC7iXTTutB0MkMm260hKxlzIXSTnxuTuIxre2MBSokhLkfth8dQQYVPQ==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/knip/-/knip-6.7.0.tgz",
+			"integrity": "sha512-ckL51NDH1YJxnv1kNB0iUdDngB4f/e9Igz8uIqYfmNDoyOFmmk1V0WFv3LQ7/hzC63b2Z9X41gGUE9eOWrZpaA==",
 			"dev": true,
 			"funding": [
 				{
@@ -3066,19 +3018,18 @@
 			],
 			"license": "ISC",
 			"dependencies": {
-				"@nodelib/fs.walk": "^1.2.3",
+				"fdir": "^6.5.0",
 				"formatly": "^0.3.0",
 				"get-tsconfig": "4.14.0",
 				"jiti": "^2.6.0",
 				"minimist": "^1.2.8",
-				"oxc-parser": "^0.126.0",
+				"oxc-parser": "^0.127.0",
 				"oxc-resolver": "^11.19.1",
-				"picocolors": "^1.1.1",
 				"picomatch": "^4.0.4",
 				"smol-toml": "^1.6.1",
 				"strip-json-comments": "5.0.3",
 				"tinyglobby": "^0.2.16",
-				"unbash": "^2.2.0",
+				"unbash": "^3.0.0",
 				"yaml": "^2.8.2",
 				"zod": "^4.1.11"
 			},
@@ -3263,13 +3214,13 @@
 			}
 		},
 		"node_modules/oxc-parser": {
-			"version": "0.126.0",
-			"resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.126.0.tgz",
-			"integrity": "sha512-FktCvLby/mOHyuijZt22+nOt10dS24gGUZE3XwIbUg7Kf4+rer3/5T7RgwzazlNuVsCjPloZ3p8E+4ONT3A8Kw==",
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.127.0.tgz",
+			"integrity": "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "^0.126.0"
+				"@oxc-project/types": "^0.127.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
@@ -3278,26 +3229,26 @@
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxc-parser/binding-android-arm-eabi": "0.126.0",
-				"@oxc-parser/binding-android-arm64": "0.126.0",
-				"@oxc-parser/binding-darwin-arm64": "0.126.0",
-				"@oxc-parser/binding-darwin-x64": "0.126.0",
-				"@oxc-parser/binding-freebsd-x64": "0.126.0",
-				"@oxc-parser/binding-linux-arm-gnueabihf": "0.126.0",
-				"@oxc-parser/binding-linux-arm-musleabihf": "0.126.0",
-				"@oxc-parser/binding-linux-arm64-gnu": "0.126.0",
-				"@oxc-parser/binding-linux-arm64-musl": "0.126.0",
-				"@oxc-parser/binding-linux-ppc64-gnu": "0.126.0",
-				"@oxc-parser/binding-linux-riscv64-gnu": "0.126.0",
-				"@oxc-parser/binding-linux-riscv64-musl": "0.126.0",
-				"@oxc-parser/binding-linux-s390x-gnu": "0.126.0",
-				"@oxc-parser/binding-linux-x64-gnu": "0.126.0",
-				"@oxc-parser/binding-linux-x64-musl": "0.126.0",
-				"@oxc-parser/binding-openharmony-arm64": "0.126.0",
-				"@oxc-parser/binding-wasm32-wasi": "0.126.0",
-				"@oxc-parser/binding-win32-arm64-msvc": "0.126.0",
-				"@oxc-parser/binding-win32-ia32-msvc": "0.126.0",
-				"@oxc-parser/binding-win32-x64-msvc": "0.126.0"
+				"@oxc-parser/binding-android-arm-eabi": "0.127.0",
+				"@oxc-parser/binding-android-arm64": "0.127.0",
+				"@oxc-parser/binding-darwin-arm64": "0.127.0",
+				"@oxc-parser/binding-darwin-x64": "0.127.0",
+				"@oxc-parser/binding-freebsd-x64": "0.127.0",
+				"@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0",
+				"@oxc-parser/binding-linux-arm-musleabihf": "0.127.0",
+				"@oxc-parser/binding-linux-arm64-gnu": "0.127.0",
+				"@oxc-parser/binding-linux-arm64-musl": "0.127.0",
+				"@oxc-parser/binding-linux-ppc64-gnu": "0.127.0",
+				"@oxc-parser/binding-linux-riscv64-gnu": "0.127.0",
+				"@oxc-parser/binding-linux-riscv64-musl": "0.127.0",
+				"@oxc-parser/binding-linux-s390x-gnu": "0.127.0",
+				"@oxc-parser/binding-linux-x64-gnu": "0.127.0",
+				"@oxc-parser/binding-linux-x64-musl": "0.127.0",
+				"@oxc-parser/binding-openharmony-arm64": "0.127.0",
+				"@oxc-parser/binding-wasm32-wasi": "0.127.0",
+				"@oxc-parser/binding-win32-arm64-msvc": "0.127.0",
+				"@oxc-parser/binding-win32-ia32-msvc": "0.127.0",
+				"@oxc-parser/binding-win32-x64-msvc": "0.127.0"
 			}
 		},
 		"node_modules/oxc-resolver": {
@@ -3588,27 +3539,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/queue-microtask": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/readdirp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -3631,17 +3561,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-			}
-		},
-		"node_modules/reusify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"iojs": ">=1.0.0",
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/rollup": {
@@ -3687,30 +3606,6 @@
 				"@rollup/rollup-win32-x64-gnu": "4.59.0",
 				"@rollup/rollup-win32-x64-msvc": "4.59.0",
 				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/run-parallel": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
 			}
 		},
 		"node_modules/sade": {
@@ -4002,9 +3897,9 @@
 			}
 		},
 		"node_modules/unbash": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/unbash/-/unbash-2.2.0.tgz",
-			"integrity": "sha512-X2wH19RAPZE3+ldGicOkoj/SIA83OIxcJ6Cuaw23hf8Xc6fQpvZXY0SftE2JgS0QhYLUG4uwodSI3R53keyh7w==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/unbash/-/unbash-3.0.0.tgz",
+			"integrity": "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ml-paper-reading-group-site",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ml-paper-reading-group-site",
-			"version": "0.0.3",
+			"version": "0.0.4",
 			"devDependencies": {
 				"@eslint/compat": "^2.0.4",
 				"@eslint/js": "^9.39.1",
@@ -16,7 +16,7 @@
 				"@types/node": "25.6.0",
 				"eslint": "^10.2.1",
 				"eslint-config-prettier": "^10.1.8",
-				"eslint-plugin-svelte": "3.17.0",
+				"eslint-plugin-svelte": "3.17.1",
 				"globals": "^17.5.0",
 				"knip": "6.5.0",
 				"prettier": "^3.8.2",
@@ -2544,9 +2544,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-svelte": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.17.0.tgz",
-			"integrity": "sha512-sF6wgd5FLS2P8CCaOy2HdYYYEcZ6TwL251dLHUkNmtLnWECk1Dwc+j6VeulmmnFxr7Xs0WNtjweOA+bJ0PnaFw==",
+			"version": "3.17.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.17.1.tgz",
+			"integrity": "sha512-NyiXHtS3Ni7e532RBwS9OXlMKDIrENg3gY+/+ODjZzQx2xhU3NlJ+nIl1a93iUUQeiJL3lS8KLmY+W8hklzweQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"svelte": "5.55.5",
 				"svelte-check": "4.4.6",
 				"typescript": "^6.0.3",
-				"typescript-eslint": "8.58.0",
+				"typescript-eslint": "8.59.1",
 				"vite": "7.3.2"
 			}
 		},
@@ -1986,17 +1986,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
-			"integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
+			"integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.58.0",
-				"@typescript-eslint/type-utils": "8.58.0",
-				"@typescript-eslint/utils": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0",
+				"@typescript-eslint/scope-manager": "8.59.1",
+				"@typescript-eslint/type-utils": "8.59.1",
+				"@typescript-eslint/utils": "8.59.1",
+				"@typescript-eslint/visitor-keys": "8.59.1",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -2009,7 +2009,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.58.0",
+				"@typescript-eslint/parser": "^8.59.1",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
@@ -2025,16 +2025,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
-			"integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
+			"integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.58.0",
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0",
+				"@typescript-eslint/scope-manager": "8.59.1",
+				"@typescript-eslint/types": "8.59.1",
+				"@typescript-eslint/typescript-estree": "8.59.1",
+				"@typescript-eslint/visitor-keys": "8.59.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2050,14 +2050,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
-			"integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+			"integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.58.0",
-				"@typescript-eslint/types": "^8.58.0",
+				"@typescript-eslint/tsconfig-utils": "^8.59.1",
+				"@typescript-eslint/types": "^8.59.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2072,14 +2072,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
-			"integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+			"integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0"
+				"@typescript-eslint/types": "8.59.1",
+				"@typescript-eslint/visitor-keys": "8.59.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2090,9 +2090,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
-			"integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+			"integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2107,15 +2107,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
-			"integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
+			"integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0",
-				"@typescript-eslint/utils": "8.58.0",
+				"@typescript-eslint/types": "8.59.1",
+				"@typescript-eslint/typescript-estree": "8.59.1",
+				"@typescript-eslint/utils": "8.59.1",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -2132,9 +2132,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
-			"integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+			"integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2146,16 +2146,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
-			"integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+			"integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.58.0",
-				"@typescript-eslint/tsconfig-utils": "8.58.0",
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0",
+				"@typescript-eslint/project-service": "8.59.1",
+				"@typescript-eslint/tsconfig-utils": "8.59.1",
+				"@typescript-eslint/types": "8.59.1",
+				"@typescript-eslint/visitor-keys": "8.59.1",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -2174,16 +2174,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
-			"integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
+			"integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.58.0",
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0"
+				"@typescript-eslint/scope-manager": "8.59.1",
+				"@typescript-eslint/types": "8.59.1",
+				"@typescript-eslint/typescript-estree": "8.59.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2198,13 +2198,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
-			"integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+			"integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.0",
+				"@typescript-eslint/types": "8.59.1",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -3978,16 +3978,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.0.tgz",
-			"integrity": "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==",
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz",
+			"integrity": "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.58.0",
-				"@typescript-eslint/parser": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0",
-				"@typescript-eslint/utils": "8.58.0"
+				"@typescript-eslint/eslint-plugin": "8.59.1",
+				"@typescript-eslint/parser": "8.59.1",
+				"@typescript-eslint/typescript-estree": "8.59.1",
+				"@typescript-eslint/utils": "8.59.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"prettier-plugin-svelte": "^3.5.1",
 		"prettier": "^3.8.2",
 		"svelte-check": "4.4.6",
-		"svelte": "5.55.3",
+		"svelte": "5.55.5",
 		"typescript-eslint": "8.58.0",
 		"typescript": "^6.0.3",
 		"vite": "7.3.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"prettier": "^3.8.2",
 		"svelte-check": "4.4.6",
 		"svelte": "5.55.5",
-		"typescript-eslint": "8.58.0",
+		"typescript-eslint": "8.59.1",
 		"typescript": "^6.0.3",
 		"vite": "7.3.2",
 		"knip": "6.5.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"@types/node": "25.6.0",
 		"eslint-config-prettier": "^10.1.8",
-		"eslint-plugin-svelte": "3.17.0",
+		"eslint-plugin-svelte": "3.17.1",
 		"eslint": "^10.2.1",
 		"globals": "^17.5.0",
 		"prettier-plugin-svelte": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
 		"typescript-eslint": "8.59.1",
 		"typescript": "^6.0.3",
 		"vite": "7.3.2",
-		"knip": "6.5.0"
+		"knip": "6.7.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ml-paper-reading-group-site",
 	"private": true,
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## Summary

- Bumps several deps

### Closes the following PRs:
- PR #103 
- PR #104 
- PR #105 
- PR #106 
- PR #107 

## Changes

- [ ] Content update (papers/schedule/leadership)
- [ ] UI update (routes/components/styles)
- [ ] CI/Deploy update (workflows)
- [x] Dependencies

## Checklist

- [x] `make lint`
- [x] `make check`
- [x] `make build`
- [x] `make deps.check`
- [x] Pages links/routes still work (esp. `/papers` and `/schedule`)
- [x] Updated data in `src/lib/data/` if applicable
