### PR TITLE
chore: dep bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "ml-paper-reading-group-site",
 			"version": "0.0.6",
 			"devDependencies": {
-				"@eslint/compat": "2.0.4",
+				"@eslint/compat": "2.1.0",
 				"@eslint/js": "9.39.1",
 				"@sveltejs/adapter-static": "3.0.10",
 				"@sveltejs/kit": "2.59.0",
@@ -547,13 +547,13 @@
 			}
 		},
 		"node_modules/@eslint/compat": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.0.4.tgz",
-			"integrity": "sha512-o598tCGstJv9Kk4XapwP+oDij9HD9Qr3V37ABzTfdzVvbFciV+sfg9zSW6olj6G/IXj7p89SwSzPnZ+JUEPIPg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
+			"integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.2.0"
+				"@eslint/core": "^1.2.1"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ml-paper-reading-group-site",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ml-paper-reading-group-site",
-			"version": "0.0.5",
+			"version": "0.0.6",
 			"devDependencies": {
 				"@eslint/compat": "2.0.4",
 				"@eslint/js": "9.39.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"globals": "17.5.0",
 				"knip": "6.11.0",
 				"prettier": "3.8.2",
-				"prettier-plugin-svelte": "3.5.1",
+				"prettier-plugin-svelte": "3.5.2",
 				"svelte": "5.55.5",
 				"svelte-check": "4.4.8",
 				"typescript": "6.0.3",
@@ -3494,9 +3494,9 @@
 			}
 		},
 		"node_modules/prettier-plugin-svelte": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.1.tgz",
-			"integrity": "sha512-65+fr5+cgIKWKiqM1Doum4uX6bY8iFCdztvvp2RcF+AJoieaw9kJOFMNcJo/bkmKYsxFaM9OsVZK/gWauG/5mg==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.2.tgz",
+			"integrity": "sha512-ItFouLvzSFE3ulNl4DKoWM3BGcbDCNVpIyy/Y3F2gC3aNiGLxtFUdffVqO5Z5hhYG+DFT5KULWaxmeFFpdbvaQ==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2236,9 +2236,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2348,10 +2348,11 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.6.4",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-			"integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
-			"dev": true
+			"version": "5.8.1",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+			"integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/esbuild": {
 			"version": "0.27.2",
@@ -3134,9 +3135,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3331,9 +3332,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -3351,7 +3352,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"prettier": "3.8.2",
 				"prettier-plugin-svelte": "3.5.1",
 				"svelte": "5.55.5",
-				"svelte-check": "4.4.7",
+				"svelte-check": "4.4.8",
 				"typescript": "6.0.3",
 				"typescript-eslint": "8.59.2",
 				"vite": "7.3.2"
@@ -3719,9 +3719,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.4.7",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.7.tgz",
-			"integrity": "sha512-JRafFTRmaPUOqmri4u1WuIKgBLiHi6wIaB57i99pmHq5BAc3ioIpzdUN/RX32ij9GhI6ALMHKvnVxu68sFZlag==",
+			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.8.tgz",
+			"integrity": "sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"svelte": "5.55.5",
 				"svelte-check": "4.4.8",
 				"typescript": "6.0.3",
-				"typescript-eslint": "8.59.2",
+				"typescript-eslint": "8.59.3",
 				"vite": "7.3.2"
 			}
 		},
@@ -1923,17 +1923,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-			"integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+			"integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.59.2",
-				"@typescript-eslint/type-utils": "8.59.2",
-				"@typescript-eslint/utils": "8.59.2",
-				"@typescript-eslint/visitor-keys": "8.59.2",
+				"@typescript-eslint/scope-manager": "8.59.3",
+				"@typescript-eslint/type-utils": "8.59.3",
+				"@typescript-eslint/utils": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -1946,7 +1946,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.59.2",
+				"@typescript-eslint/parser": "^8.59.3",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
@@ -1962,16 +1962,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-			"integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+			"integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.59.2",
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/typescript-estree": "8.59.2",
-				"@typescript-eslint/visitor-keys": "8.59.2",
+				"@typescript-eslint/scope-manager": "8.59.3",
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/typescript-estree": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1987,14 +1987,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-			"integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+			"integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.59.2",
-				"@typescript-eslint/types": "^8.59.2",
+				"@typescript-eslint/tsconfig-utils": "^8.59.3",
+				"@typescript-eslint/types": "^8.59.3",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2009,14 +2009,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-			"integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+			"integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/visitor-keys": "8.59.2"
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2027,9 +2027,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-			"integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+			"integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2044,15 +2044,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-			"integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+			"integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/typescript-estree": "8.59.2",
-				"@typescript-eslint/utils": "8.59.2",
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/typescript-estree": "8.59.3",
+				"@typescript-eslint/utils": "8.59.3",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -2069,9 +2069,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-			"integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+			"integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2083,16 +2083,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-			"integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+			"integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.59.2",
-				"@typescript-eslint/tsconfig-utils": "8.59.2",
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/visitor-keys": "8.59.2",
+				"@typescript-eslint/project-service": "8.59.3",
+				"@typescript-eslint/tsconfig-utils": "8.59.3",
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -2111,16 +2111,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-			"integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+			"integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.59.2",
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/typescript-estree": "8.59.2"
+				"@typescript-eslint/scope-manager": "8.59.3",
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/typescript-estree": "8.59.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2135,13 +2135,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-			"integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+			"integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/types": "8.59.3",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -3848,16 +3848,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
-			"integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+			"integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.59.2",
-				"@typescript-eslint/parser": "8.59.2",
-				"@typescript-eslint/typescript-estree": "8.59.2",
-				"@typescript-eslint/utils": "8.59.2"
+				"@typescript-eslint/eslint-plugin": "8.59.3",
+				"@typescript-eslint/parser": "8.59.3",
+				"@typescript-eslint/typescript-estree": "8.59.3",
+				"@typescript-eslint/utils": "8.59.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@sveltejs/adapter-static": "3.0.10",
 				"@sveltejs/kit": "2.59.0",
 				"@sveltejs/vite-plugin-svelte": "6.2.1",
-				"@types/node": "25.6.0",
+				"@types/node": "25.7.0",
 				"eslint": "10.2.1",
 				"eslint-config-prettier": "10.1.8",
 				"eslint-plugin-svelte": "3.17.1",
@@ -1906,13 +1906,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"version": "25.7.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+			"integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.19.0"
+				"undici-types": "~7.21.0"
 			}
 		},
 		"node_modules/@types/trusted-types": {
@@ -3882,9 +3882,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.19.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+			"integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"prettier": "3.8.2",
 		"svelte-check": "4.4.8",
 		"svelte": "5.55.5",
-		"typescript-eslint": "8.59.2",
+		"typescript-eslint": "8.59.3",
 		"typescript": "6.0.3",
 		"vite": "7.3.2",
 		"knip": "6.11.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ml-paper-reading-group-site",
 	"private": true,
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@sveltejs/adapter-static": "3.0.10",
 		"@sveltejs/kit": "2.59.0",
 		"@sveltejs/vite-plugin-svelte": "6.2.1",
-		"@types/node": "25.6.0",
+		"@types/node": "25.7.0",
 		"eslint-config-prettier": "10.1.8",
 		"eslint-plugin-svelte": "3.17.1",
 		"eslint": "10.2.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"globals": "17.5.0",
 		"prettier-plugin-svelte": "3.5.1",
 		"prettier": "3.8.2",
-		"svelte-check": "4.4.7",
+		"svelte-check": "4.4.8",
 		"svelte": "5.55.5",
 		"typescript-eslint": "8.59.2",
 		"typescript": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"lint": "prettier --check . && eslint ."
 	},
 	"devDependencies": {
-		"@eslint/compat": "2.0.4",
+		"@eslint/compat": "2.1.0",
 		"@eslint/js": "9.39.1",
 		"@sveltejs/adapter-static": "3.0.10",
 		"@sveltejs/kit": "2.59.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"eslint-plugin-svelte": "3.17.1",
 		"eslint": "10.2.1",
 		"globals": "17.5.0",
-		"prettier-plugin-svelte": "3.5.1",
+		"prettier-plugin-svelte": "3.5.2",
 		"prettier": "3.8.2",
 		"svelte-check": "4.4.8",
 		"svelte": "5.55.5",


### PR DESCRIPTION
## Summary
- Bumps several deps (1 high)
- Closes the following PRs:
    - #115 
    - #116 
    - #117  
    - #118 
    - #119 

## Changes

- [ ] Content update (papers/schedule/leadership)
- [ ] UI update (routes/components/styles)
- [ ] CI/Deploy update (workflows)
- [x] Dependencies

## Checklist

- [x] `make lint`
- [x] `make check`
- [x] `make build`
- [x] `make deps.check`
- [x] Pages links/routes still work (esp. `/papers` and `/schedule`)
- [x] Updated data in `src/lib/data/` if applicable


