### PR TITLE
chore: dep bumps & readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Static website for the **ML Paper Reading Group** (Augusta University), built with **Svelte 5 + SvelteKit** and deployed to **GitHub Pages** via **GitHub Actions**.
 
-URL: https://sethbarrett50.github.io/ml-paper-reading-group-website/
+URL: https://sethbarrett50.github.io/mlprg-website/
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"knip": "6.14.1",
 				"prettier": "3.8.2",
 				"prettier-plugin-svelte": "3.5.2",
-				"svelte": "5.55.5",
+				"svelte": "5.55.8",
 				"svelte-check": "4.4.8",
 				"typescript": "6.0.3",
 				"typescript-eslint": "8.59.3",
@@ -3692,9 +3692,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.55.5",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
-			"integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
+			"version": "5.55.8",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.8.tgz",
+			"integrity": "sha512-4D6lyrMHmDaZalQOEBMCWCCidyZjSnec14/oPn0k627G6goxcck9xqMwz1tFLlQz+ZFvtTTHfFOlUayuAz0z6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3707,7 +3707,7 @@
 				"aria-query": "5.3.1",
 				"axobject-query": "^4.1.0",
 				"clsx": "^2.1.1",
-				"devalue": "^5.6.4",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.1",
 				"esrap": "^2.2.4",
 				"is-reference": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"svelte": "5.55.8",
 				"svelte-check": "4.4.8",
 				"typescript": "6.0.3",
-				"typescript-eslint": "8.59.3",
+				"typescript-eslint": "8.59.4",
 				"vite": "7.3.2"
 			}
 		},
@@ -1923,17 +1923,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
-			"integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
+			"integrity": "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.59.3",
-				"@typescript-eslint/type-utils": "8.59.3",
-				"@typescript-eslint/utils": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3",
+				"@typescript-eslint/scope-manager": "8.59.4",
+				"@typescript-eslint/type-utils": "8.59.4",
+				"@typescript-eslint/utils": "8.59.4",
+				"@typescript-eslint/visitor-keys": "8.59.4",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -1946,7 +1946,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.59.3",
+				"@typescript-eslint/parser": "^8.59.4",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
@@ -1962,16 +1962,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
-			"integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
+			"integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.59.3",
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3",
+				"@typescript-eslint/scope-manager": "8.59.4",
+				"@typescript-eslint/types": "8.59.4",
+				"@typescript-eslint/typescript-estree": "8.59.4",
+				"@typescript-eslint/visitor-keys": "8.59.4",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1987,14 +1987,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
-			"integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
+			"integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.59.3",
-				"@typescript-eslint/types": "^8.59.3",
+				"@typescript-eslint/tsconfig-utils": "^8.59.4",
+				"@typescript-eslint/types": "^8.59.4",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2009,14 +2009,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
-			"integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
+			"integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3"
+				"@typescript-eslint/types": "8.59.4",
+				"@typescript-eslint/visitor-keys": "8.59.4"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2027,9 +2027,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
-			"integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
+			"integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2044,15 +2044,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
-			"integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz",
+			"integrity": "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3",
-				"@typescript-eslint/utils": "8.59.3",
+				"@typescript-eslint/types": "8.59.4",
+				"@typescript-eslint/typescript-estree": "8.59.4",
+				"@typescript-eslint/utils": "8.59.4",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -2069,9 +2069,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-			"integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
+			"integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2083,16 +2083,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
-			"integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
+			"integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.59.3",
-				"@typescript-eslint/tsconfig-utils": "8.59.3",
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3",
+				"@typescript-eslint/project-service": "8.59.4",
+				"@typescript-eslint/tsconfig-utils": "8.59.4",
+				"@typescript-eslint/types": "8.59.4",
+				"@typescript-eslint/visitor-keys": "8.59.4",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -2111,16 +2111,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
-			"integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz",
+			"integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.59.3",
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3"
+				"@typescript-eslint/scope-manager": "8.59.4",
+				"@typescript-eslint/types": "8.59.4",
+				"@typescript-eslint/typescript-estree": "8.59.4"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2135,13 +2135,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
-			"integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
+			"integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/types": "8.59.4",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -3849,16 +3849,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
-			"integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.4.tgz",
+			"integrity": "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.59.3",
-				"@typescript-eslint/parser": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3",
-				"@typescript-eslint/utils": "8.59.3"
+				"@typescript-eslint/eslint-plugin": "8.59.4",
+				"@typescript-eslint/parser": "8.59.4",
+				"@typescript-eslint/typescript-estree": "8.59.4",
+				"@typescript-eslint/utils": "8.59.4"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@sveltejs/adapter-static": "3.0.10",
 				"@sveltejs/kit": "2.59.0",
 				"@sveltejs/vite-plugin-svelte": "6.2.1",
-				"@types/node": "25.7.0",
+				"@types/node": "25.9.1",
 				"eslint": "10.2.1",
 				"eslint-config-prettier": "10.1.8",
 				"eslint-plugin-svelte": "3.17.1",
@@ -1906,13 +1906,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.7.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-			"integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+			"version": "25.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.21.0"
+				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
 		"node_modules/@types/trusted-types": {
@@ -3883,9 +3883,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-			"integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"eslint-plugin-svelte": "3.17.1",
 				"globals": "17.5.0",
 				"knip": "6.14.1",
-				"prettier": "3.8.2",
+				"prettier": "3.8.3",
 				"prettier-plugin-svelte": "3.5.2",
 				"svelte": "5.55.8",
 				"svelte-check": "4.4.8",
@@ -3479,9 +3479,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
-			"integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"eslint-config-prettier": "10.1.8",
 				"eslint-plugin-svelte": "3.17.1",
 				"globals": "17.5.0",
-				"knip": "6.11.0",
+				"knip": "6.14.1",
 				"prettier": "3.8.2",
 				"prettier-plugin-svelte": "3.5.2",
 				"svelte": "5.55.5",
@@ -767,9 +767,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-android-arm-eabi": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.128.0.tgz",
-			"integrity": "sha512-aca6ZvzmCBUGOANQRiRQRZuRKYI3ENhcit6GisnknOOmcezfQc7xJ4dxlPU7MV7mOvrC7RNR1u3LAD7xyaiCxA==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.130.0.tgz",
+			"integrity": "sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw==",
 			"cpu": [
 				"arm"
 			],
@@ -784,9 +784,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-android-arm64": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.128.0.tgz",
-			"integrity": "sha512-BbeDmuohoJ7Rz/it5wnkj69i/OsCPS3Z51nLEzwO/Y6YshtC4JU+15oNwhY8v4LRKRYclRc7ggOikwrsJ/eOEQ==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.130.0.tgz",
+			"integrity": "sha512-oFWFJrsGv9siFM4HjMqKNB7IuIZD/SMmZdCXl8xyx7lDplGvPKyewpOo272rSWgMXe2Wx7bWI0Yj+gkHv4qbeg==",
 			"cpu": [
 				"arm64"
 			],
@@ -801,9 +801,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-darwin-arm64": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.128.0.tgz",
-			"integrity": "sha512-tRUHPt80417QmvNpoSslJT1VY8NUbWdrWR+L14Zn+RbOTcaqB8E6PYE/ZGN8jjWBzqporiA/H4MfO50ew/NCNA==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.130.0.tgz",
+			"integrity": "sha512-sGUzupdTplK9jQg7eJZ878HfEgQjJNBc6dAYVWJ9W5aU+J8rLfRJhTVsKThiu1pNwm6Y1qKCcbC6WhNWSXR3Ig==",
 			"cpu": [
 				"arm64"
 			],
@@ -818,9 +818,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-darwin-x64": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.128.0.tgz",
-			"integrity": "sha512-rWI2Hb1Nt3U/vKsjyNvZzDC8i/l144U20DKjhzaTmwIhIiSRGeroPWWiImwypmKLqrw8GuIixbWJkpGWLbkzrQ==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.130.0.tgz",
+			"integrity": "sha512-PsB4cdCISbC00Uy8eiD8bc2AkGWjZqrSrJnkBFuG2ptrrf6mZ2F5gLFSjOAVMMgZPg8B1D7OydJwLWSfyI2Plg==",
 			"cpu": [
 				"x64"
 			],
@@ -835,9 +835,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-freebsd-x64": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.128.0.tgz",
-			"integrity": "sha512-hhpdVMaNCLgQxjgNPeeFzSeJMmZPc5lKfv0NGSI3egZq9EdnEGqeC8JsYsQjK7PoQgbvZ17xlj0SO5ziH5Obkg==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.130.0.tgz",
+			"integrity": "sha512-DgABp3l38hS77JbXCV4qk1+n6DPym5u8zzwuweokezm2tX194nDSJDENbDRECxVsiNbprKATLbk+Z5wlHT0OHw==",
 			"cpu": [
 				"x64"
 			],
@@ -852,9 +852,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.128.0.tgz",
-			"integrity": "sha512-093zNw0zZ/e/obML+rhlSdmnzR0mVZluPcAkxunEc5E3F0yBVsFn24Y1ILfsEte11Ud041qn/gp2OJ1jxNqUng==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.130.0.tgz",
+			"integrity": "sha512-4Kn3CTEmwFrzhTSC/JuUW16qovmaMdX7jeSKbL8w0pLtLww7To1a2XJi9Z5uD8QWUkfUHhqfV+VD6dVzBnWzoA==",
 			"cpu": [
 				"arm"
 			],
@@ -869,9 +869,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.128.0.tgz",
-			"integrity": "sha512-fq7DmKmfC+dvD97IXrgbph6Jzwe0EDu+PYMofmzZ6fv5X1k9vtaqLpDGMuICO9MmUnyKAQmVl+wIv2RNy4Dz8g==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.130.0.tgz",
+			"integrity": "sha512-D35KZM3F4rRu1uAFKyBlg3Gaf/ybCjyaPR1hfgvk5ex8NtcTmRgc0JgSighEyNg96TPrFhemFba68SZuxaha8w==",
 			"cpu": [
 				"arm"
 			],
@@ -886,9 +886,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.128.0.tgz",
-			"integrity": "sha512-Xvm48jJah8TlIrURIjNOP/gNiGe6aKvCB+r06VliflFo8Kq7VOLE8PxtgShJzZIqubrgdMdYfvuPPozn7F6MbQ==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.130.0.tgz",
+			"integrity": "sha512-Q9o7oVlo955KHwS8l1u0bCzIx+JsZUA3XToLXC+MsMhye/9LeBQbt84nh120cl2XLy+TEzvugYDiHShg5yaX6Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -903,9 +903,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm64-musl": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.128.0.tgz",
-			"integrity": "sha512-M7iwBGmYJTx+pKOYFjI0buop4gJvlmcVzFGaXPt21DKpQkbQZG1f63Yg7LloIYT/t9yLxCw0Lhfx/RFlAlMSjA==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.130.0.tgz",
+			"integrity": "sha512-EiJ/gC0ljbcwVpycC8YWw6ggMbtsPX8XMOt0mPx0aqWeMsNR+L9m05Flbvd5T+GlivG+GkSWQL7tM9SRFpM/dw==",
 			"cpu": [
 				"arm64"
 			],
@@ -920,9 +920,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.128.0.tgz",
-			"integrity": "sha512-21LGNIZb1Pcfk5/EGsqabrxv4yqQOWis1407JJrClS7XpFCrbvr74YAB1V+m54cYbwvO6UWwQqS4WecxiyfCRg==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.130.0.tgz",
+			"integrity": "sha512-b+h/lsLLurp756dMGizNs5uPaJfyEdWrTcV5t8M609jWm1DEHB1StpRXCkyvwtkJx3m+qL5BNQ0dEKan/4yGFA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -937,9 +937,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.128.0.tgz",
-			"integrity": "sha512-gyHjOTFpg9bTTYjxPmQirvufb89+VdZwVfcMtAUyPr6F5H8ZswvCQshK4qOW+Q+2Xyb33hduRgY/eFHJQjU/vQ==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.130.0.tgz",
+			"integrity": "sha512-O19Cil83XAyjEFfo8WhkMwY58ALqZ7ckjGL+25mjMIuF84urWBeANH0FC8B8BsSSygWU3/1aY3ADdDbp+wlBnw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -954,9 +954,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.128.0.tgz",
-			"integrity": "sha512-X6Q2oKUrP5GyDd2xniuEBLk6aFQCZ97W2+aVXGgJXdjx5t4/oFuA9ri0wLOUrBIX+qdSuK581snMBio4z910eA==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.130.0.tgz",
+			"integrity": "sha512-BgXRVC0+83n3YzCscLQjj6nbyeBIVeZYPTI4fFMAE4WNm2+4RXhWp03IVizL7esIz36kgmT48aebk1iM+cs8sw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -971,9 +971,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.128.0.tgz",
-			"integrity": "sha512-BdzTmqxfxoYkpgokoLaSnOX6T+R3/goL42klre2tnG+kHbG2TXS0VN+P5BPofH1axdKOHy5ei4ENZrjmCOt2lA==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.130.0.tgz",
+			"integrity": "sha512-6tJz0xvnGhsokE7N1WlUSBXibpYmT9xSJFS1Ce41Km/+8gQvdlW8MLhRv8PD0L7ix8vRG0FDDepp3jdOFzdVdw==",
 			"cpu": [
 				"s390x"
 			],
@@ -988,9 +988,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-x64-gnu": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.128.0.tgz",
-			"integrity": "sha512-OO1nW2Q7sSYYvJZpDHdvyFSdRaVcQqRijZSSmWVMqFxPYy8cEF45zJ9fcdIYuzIT3jYq6YRhEFm/VMWNWhE22Q==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.130.0.tgz",
+			"integrity": "sha512-9aCWj83dp3heTQGmGnZGdIWgxjZrr/7VQ0TGFHH5PKByxJKF2Hcr4qvaSUHhhGEa3MSsDjTL1YDP8RAgdL5/Cg==",
 			"cpu": [
 				"x64"
 			],
@@ -1005,9 +1005,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-x64-musl": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.128.0.tgz",
-			"integrity": "sha512-4NehAe404MRdoZVS9DW8C5XbJwbXIc/KfVlYdpi5vE4081zc9Y0YzKVqyOYj/Puye7/Do+ohaONBFWlEHYl9hw==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.130.0.tgz",
+			"integrity": "sha512-afXt87aZBqrUVli8TB/I8H1G50RDWcwirjWtXGXYqJ2ZqWEiErH7V72j3LUSDZaivmtu2OLX0KQ/mbhP81mr7A==",
 			"cpu": [
 				"x64"
 			],
@@ -1022,9 +1022,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-openharmony-arm64": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.128.0.tgz",
-			"integrity": "sha512-kVbqgW9xLL8bh8oc7aYOJilRKXE5G33+tE0jan+duo/9OriaFRpijcCwT2waWs2oqYROYq0GlE7/p3ywoshVeg==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.130.0.tgz",
+			"integrity": "sha512-I0NCrZV/YZuCGWgqwNN/GO/iXlLF2z+Wgc7u+Aa9N4P51oYeIa0XT+zVBUne4csO9GqxskXgI4g8JzzWGRpfOw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1039,9 +1039,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-wasm32-wasi": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.128.0.tgz",
-			"integrity": "sha512-L38ojghJYHmgiz6fJd7jwLB/ESDBpB02NdFxh+smqVM6P2anCEvHn0jhaSrt5eVNR1Ak8+moOeftUlofeyvniA==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.130.0.tgz",
+			"integrity": "sha512-sJgQkGaBX0WJvPUDfwciex6IcTk5O5NLQ1bhEb6f3nBruh1GshKMRSMt2bxZlYrgBzjyBbJzsnO+InPG0bg+fA==",
 			"cpu": [
 				"wasm32"
 			],
@@ -1058,9 +1058,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.128.0.tgz",
-			"integrity": "sha512-xgvO35GyHBtjlQ5AEpaYr7Rll1rvY7zqIhT6ty8E3ezBW2J1SFLjIDEvI/tcgDg6oaseDAqVcM+jU1HuCekgZw==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.130.0.tgz",
+			"integrity": "sha512-bjcma99sQrNh6RY4mPO9yTkfxql6TDFoN3HWdK31RCKXwNhcDgJXW/l8PUtzKNiQ+9vpKJfJtQq+LklBuxSOBA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1075,9 +1075,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.128.0.tgz",
-			"integrity": "sha512-OY+3eM2SN72prHKRB22mPz8o5A/7dJ+f5DFLBVvggyZhEaNDAH9IB+ElMjmOkOIwf5MDCUAowCK7pAncNxzpBA==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.130.0.tgz",
+			"integrity": "sha512-hRYbv6HhpSTzT4xTiIkadLI7upLQxuOdLPR/9nL1fTjwhgutBTPXrwaAPb/jTFVx6/8C7Jb5HcUKhmNwloTbFA==",
 			"cpu": [
 				"ia32"
 			],
@@ -1092,9 +1092,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-win32-x64-msvc": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.128.0.tgz",
-			"integrity": "sha512-NE9ny+cPUCCObXa0IKLfj0tCdPd7pe/dz9ZpkxpUOymB3miNeMPybdlYYTBSGJUalMWeBM85/4JcCErCNTqOXw==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.130.0.tgz",
+			"integrity": "sha512-RBpA9TsRucJq6HNVNCFF1iKg+QeTkLdZf7hi4xaOGCPvMZWvDHjQgSOEZMUpuW4JNciHbxNhLEYmz5CVygjVGQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1109,9 +1109,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
-			"integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+			"integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -2927,9 +2927,9 @@
 			"license": "ISC"
 		},
 		"node_modules/jiti": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -2978,9 +2978,9 @@
 			}
 		},
 		"node_modules/knip": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/knip/-/knip-6.11.0.tgz",
-			"integrity": "sha512-84PTlN8Q5smLpTbzs8smTVh8PMbTDXtw0tFksXq/m6auGFC/KSzJykKFmnYh3As38kiWDkoDBvdTTyKk5M1TAQ==",
+			"version": "6.14.1",
+			"resolved": "https://registry.npmjs.org/knip/-/knip-6.14.1.tgz",
+			"integrity": "sha512-SN3Ly0ixzj5CQkY/rc4OPHpWrCC0XRIIjgdP76G9Cni5k72ur5jBYOyvJuF5oPTM14v8eHcMUgPbElHa+lnR0g==",
 			"dev": true,
 			"funding": [
 				{
@@ -2997,16 +2997,16 @@
 				"fdir": "^6.5.0",
 				"formatly": "^0.3.0",
 				"get-tsconfig": "4.14.0",
-				"jiti": "^2.6.0",
+				"jiti": "^2.7.0",
 				"minimist": "^1.2.8",
-				"oxc-parser": "^0.128.0",
+				"oxc-parser": "^0.130.0",
 				"oxc-resolver": "^11.19.1",
 				"picomatch": "^4.0.4",
 				"smol-toml": "^1.6.1",
 				"strip-json-comments": "5.0.3",
 				"tinyglobby": "^0.2.16",
 				"unbash": "^3.0.0",
-				"yaml": "^2.8.2",
+				"yaml": "^2.9.0",
 				"zod": "^4.1.11"
 			},
 			"bin": {
@@ -3190,13 +3190,13 @@
 			}
 		},
 		"node_modules/oxc-parser": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.128.0.tgz",
-			"integrity": "sha512-XkOw3eiIxAgQ19WRew/Bq9wc5Ga/guaWIzDBzq80z1PyuDNGvWBpPby9k6YGwV8A8uMw+Nlq3xqlzuDYmUFYUw==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.130.0.tgz",
+			"integrity": "sha512-X0PJ+NmOok8qP3vK9uaW431ngkdM9UPEK7KG466urtIL2+EYTEgbZK2yqe2MWKJKBjRlFweP/pJPx0x9muMEVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "^0.128.0"
+				"@oxc-project/types": "^0.130.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
@@ -3205,26 +3205,26 @@
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxc-parser/binding-android-arm-eabi": "0.128.0",
-				"@oxc-parser/binding-android-arm64": "0.128.0",
-				"@oxc-parser/binding-darwin-arm64": "0.128.0",
-				"@oxc-parser/binding-darwin-x64": "0.128.0",
-				"@oxc-parser/binding-freebsd-x64": "0.128.0",
-				"@oxc-parser/binding-linux-arm-gnueabihf": "0.128.0",
-				"@oxc-parser/binding-linux-arm-musleabihf": "0.128.0",
-				"@oxc-parser/binding-linux-arm64-gnu": "0.128.0",
-				"@oxc-parser/binding-linux-arm64-musl": "0.128.0",
-				"@oxc-parser/binding-linux-ppc64-gnu": "0.128.0",
-				"@oxc-parser/binding-linux-riscv64-gnu": "0.128.0",
-				"@oxc-parser/binding-linux-riscv64-musl": "0.128.0",
-				"@oxc-parser/binding-linux-s390x-gnu": "0.128.0",
-				"@oxc-parser/binding-linux-x64-gnu": "0.128.0",
-				"@oxc-parser/binding-linux-x64-musl": "0.128.0",
-				"@oxc-parser/binding-openharmony-arm64": "0.128.0",
-				"@oxc-parser/binding-wasm32-wasi": "0.128.0",
-				"@oxc-parser/binding-win32-arm64-msvc": "0.128.0",
-				"@oxc-parser/binding-win32-ia32-msvc": "0.128.0",
-				"@oxc-parser/binding-win32-x64-msvc": "0.128.0"
+				"@oxc-parser/binding-android-arm-eabi": "0.130.0",
+				"@oxc-parser/binding-android-arm64": "0.130.0",
+				"@oxc-parser/binding-darwin-arm64": "0.130.0",
+				"@oxc-parser/binding-darwin-x64": "0.130.0",
+				"@oxc-parser/binding-freebsd-x64": "0.130.0",
+				"@oxc-parser/binding-linux-arm-gnueabihf": "0.130.0",
+				"@oxc-parser/binding-linux-arm-musleabihf": "0.130.0",
+				"@oxc-parser/binding-linux-arm64-gnu": "0.130.0",
+				"@oxc-parser/binding-linux-arm64-musl": "0.130.0",
+				"@oxc-parser/binding-linux-ppc64-gnu": "0.130.0",
+				"@oxc-parser/binding-linux-riscv64-gnu": "0.130.0",
+				"@oxc-parser/binding-linux-riscv64-musl": "0.130.0",
+				"@oxc-parser/binding-linux-s390x-gnu": "0.130.0",
+				"@oxc-parser/binding-linux-x64-gnu": "0.130.0",
+				"@oxc-parser/binding-linux-x64-musl": "0.130.0",
+				"@oxc-parser/binding-openharmony-arm64": "0.130.0",
+				"@oxc-parser/binding-wasm32-wasi": "0.130.0",
+				"@oxc-parser/binding-win32-arm64-msvc": "0.130.0",
+				"@oxc-parser/binding-win32-ia32-msvc": "0.130.0",
+				"@oxc-parser/binding-win32-x64-msvc": "0.130.0"
 			}
 		},
 		"node_modules/oxc-resolver": {
@@ -4038,9 +4038,9 @@
 			}
 		},
 		"node_modules/yaml": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ml-paper-reading-group-site",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ml-paper-reading-group-site",
-			"version": "0.0.6",
+			"version": "0.0.7",
 			"devDependencies": {
 				"@eslint/compat": "2.1.0",
 				"@eslint/js": "9.39.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"prettier-plugin-svelte": "3.5.2",
 		"prettier": "3.8.2",
 		"svelte-check": "4.4.8",
-		"svelte": "5.55.5",
+		"svelte": "5.55.8",
 		"typescript-eslint": "8.59.3",
 		"typescript": "6.0.3",
 		"vite": "7.3.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@sveltejs/adapter-static": "3.0.10",
 		"@sveltejs/kit": "2.59.0",
 		"@sveltejs/vite-plugin-svelte": "6.2.1",
-		"@types/node": "25.7.0",
+		"@types/node": "25.9.1",
 		"eslint-config-prettier": "10.1.8",
 		"eslint-plugin-svelte": "3.17.1",
 		"eslint": "10.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ml-paper-reading-group-site",
 	"private": true,
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"prettier": "3.8.2",
 		"svelte-check": "4.4.8",
 		"svelte": "5.55.8",
-		"typescript-eslint": "8.59.3",
+		"typescript-eslint": "8.59.4",
 		"typescript": "6.0.3",
 		"vite": "7.3.2",
 		"knip": "6.14.1"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"eslint": "10.2.1",
 		"globals": "17.5.0",
 		"prettier-plugin-svelte": "3.5.2",
-		"prettier": "3.8.2",
+		"prettier": "3.8.3",
 		"svelte-check": "4.4.8",
 		"svelte": "5.55.8",
 		"typescript-eslint": "8.59.4",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
 		"typescript-eslint": "8.59.3",
 		"typescript": "6.0.3",
 		"vite": "7.3.2",
-		"knip": "6.11.0"
+		"knip": "6.14.1"
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes url in README
- Bumps several deps, closing the following PRs:
    - #121 
    - #122 
    - #123 
    - #124 
    - #125 

## Changes

- [ ] Content update (papers/schedule/leadership)
- [ ] UI update (routes/components/styles)
- [ ] CI/Deploy update (workflows)
- [x] Dependencies

## Checklist

- [x] `make lint`
- [x] `make check`
- [x] `make build`
- [x] `make deps.check`
- [x] Pages links/routes still work (esp. `/papers` and `/schedule`)
- [x] Updated data in `src/lib/data/` if applicable

## Screenshots (optional)

-
